### PR TITLE
Version 0.2.12

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,7 +9,7 @@
 
 if ( ! defined( '_S_VERSION' ) ) {
 	// Replace the version number of the theme on each release.
-	define( '_S_VERSION', '0.2.11' );
+	define( '_S_VERSION', '0.2.12' );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tobias",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "",
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^6.0.0",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: custom-background, custom-logo, custom-menu, featured-images, threaded-com
 Requires at least: 4.5
 Tested up to: 5.8
 Requires PHP: 5.6
-Stable tag: 0.2.11
+Stable tag: 0.2.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 

--- a/style.css
+++ b/style.css
@@ -5,9 +5,8 @@ Author: Mira Web Services
 Author URI: https://www.tobias.com/
 Description: A lightweight starter theme for WordPress incorporating Bootstrap.
 GitHub Theme URI: https://github.com/mirawebservices/tobias
-Version: v0.2.11
+Version: v0.2.12
 Primary Branch: main
-Release Asset: true
 Tested up to: 5.9.2
 Requires PHP: 5.6
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Removed release asset. Git Updater plugin requires asset token for release asset and it's preferable to support non-access token environments.